### PR TITLE
Fix MSRV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `with_global_lock` added to `Device::open`.
+- Bumped MSRV to `1.58.0`.
 
 ## [0.0.2] - 2023-11-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["ftdi", "d3xx", "usb", "ft60x"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/mtmk-ee/d3xx"
-rust-version = "1.56.0"
+rust-version = "1.58.0"
 
 [dependencies]
 libftd3xx-ffi = { version = "0.0.2", features = [] }


### PR DESCRIPTION
`widestring` requires 1.58.0+